### PR TITLE
Netsupport

### DIFF
--- a/SerialCommand.cpp
+++ b/SerialCommand.cpp
@@ -33,7 +33,7 @@ SerialCommand::SerialCommand(int maxCommands)
     term('\n'),           // default terminator for commands, newline character
     last(NULL),
     maxCommands(maxCommands),
-	target(Serial)
+    target(&Serial)
 {
   strcpy(delim, " "); // strtok_r needs a null-terminated string
   clearBuffer();
@@ -47,15 +47,15 @@ SerialCommand::SerialCommand(int maxCommands)
  */
 void SerialCommand::addCommand(const char *command, void (*function)()) {
   #ifdef SERIALCOMMAND_DEBUG
-    target.print(F("Adding command ("));
-    target.print(commandCount);
-    target.print(F("): "));
-    target.println(command);
+    target->print(F("Adding command ("));
+    target->print(commandCount);
+    target->print(F("): "));
+    target->println(command);
   #endif
 
   if (commandCount >= maxCommands){
     #ifdef SERIALCOMMAND_DEBUG
-    target.print(F("Error: maxCommands was exceeded"));
+    target->print(F("Error: maxCommands was exceeded"));
     #endif
     return;
   }
@@ -79,16 +79,16 @@ void SerialCommand::setDefaultHandler(void (*function)(const char *)) {
  * buffer for a prefix command, and calls handlers setup by addCommand() member
  */
 void SerialCommand::readSerial() {
-  while (target.available() > 0) {
-    char inChar = target.read();   // Read single available character, there may be more waiting
+  while (target->available() > 0) {
+    char inChar = target->read();   // Read single available character, there may be more waiting
     #ifdef SERIALCOMMAND_DEBUG
-      target.print(inChar);   // Echo back to serial stream
+      target->print(inChar);   // Echo back to serial stream
     #endif
 
     if (inChar == term) {     // Check for the terminator (default '\r') meaning end of command
       #ifdef SERIALCOMMAND_DEBUG
-        target.print(F("Received: "));
-        target.println(buffer);
+        target->print(F("Received: "));
+        target->println(buffer);
       #endif
 
       char *command = strtok_r(buffer, delim, &last);   // Search for command at start of buffer
@@ -96,18 +96,18 @@ void SerialCommand::readSerial() {
         boolean matched = false;
         for (int i = 0; i < commandCount; i++) {
           #ifdef SERIALCOMMAND_DEBUG
-            target.print(F("Comparing ["));
-            target.print(command);
-            target.print(F("] to ["));
-            target.print(commandList[i].command);
-            target.println(F("]"));
+            target->print(F("Comparing ["));
+            target->print(command);
+            target->print(F("] to ["));
+            target->print(commandList[i].command);
+            target->println(F("]"));
           #endif
 
           // Compare the found command against the list of known commands for a match
           if (strncmp(command, commandList[i].command, SERIALCOMMAND_MAXCOMMANDLENGTH) == 0) {
             #ifdef SERIALCOMMAND_DEBUG
-              target.print(F("Matched Command: "));
-              target.println(command);
+              target->print(F("Matched Command: "));
+              target->println(command);
             #endif
 
             // Execute the stored handler function for the command
@@ -128,7 +128,7 @@ void SerialCommand::readSerial() {
         buffer[bufPos] = '\0';      // Null terminate
       } else {
         #ifdef SERIALCOMMAND_DEBUG
-          target.println(F("Line buffer is full - increase SERIALCOMMAND_BUFFER"));
+          target->println(F("Line buffer is full - increase SERIALCOMMAND_BUFFER"));
         #endif
       }
     }
@@ -154,10 +154,10 @@ char *SerialCommand::next() {
 /**
  * Sets the target to send output to and read input from
  */
-void SerialCommand::setTarget(Stream& target) {
-	this->target = target;
+void SerialCommand::setTarget(Stream* newTarget) {
+  this->target = newTarget;
 }
 
-Stream& SerialCommand::getTarget() {
-	return this->target;
+Stream* SerialCommand::getTarget() {
+  return this->target;
 }

--- a/SerialCommand.cpp
+++ b/SerialCommand.cpp
@@ -47,15 +47,15 @@ SerialCommand::SerialCommand(int maxCommands)
  */
 void SerialCommand::addCommand(const char *command, void (*function)()) {
   #ifdef SERIALCOMMAND_DEBUG
-    target.print("Adding command (");
+    target.print(F("Adding command ("));
     target.print(commandCount);
-    target.print("): ");
+    target.print(F("): "));
     target.println(command);
   #endif
 
   if (commandCount >= maxCommands){
     #ifdef SERIALCOMMAND_DEBUG
-    target.print("Error: maxCommands was exceeded");
+    target.print(F("Error: maxCommands was exceeded"));
     #endif
     return;
   }
@@ -87,7 +87,7 @@ void SerialCommand::readSerial() {
 
     if (inChar == term) {     // Check for the terminator (default '\r') meaning end of command
       #ifdef SERIALCOMMAND_DEBUG
-        target.print("Received: ");
+        target.print(F("Received: "));
         target.println(buffer);
       #endif
 
@@ -96,17 +96,17 @@ void SerialCommand::readSerial() {
         boolean matched = false;
         for (int i = 0; i < commandCount; i++) {
           #ifdef SERIALCOMMAND_DEBUG
-            target.print("Comparing [");
+            target.print(F("Comparing ["));
             target.print(command);
-            target.print("] to [");
+            target.print(F("] to ["));
             target.print(commandList[i].command);
-            target.println("]");
+            target.println(F("]"));
           #endif
 
           // Compare the found command against the list of known commands for a match
           if (strncmp(command, commandList[i].command, SERIALCOMMAND_MAXCOMMANDLENGTH) == 0) {
             #ifdef SERIALCOMMAND_DEBUG
-              target.print("Matched Command: ");
+              target.print(F("Matched Command: "));
               target.println(command);
             #endif
 
@@ -128,7 +128,7 @@ void SerialCommand::readSerial() {
         buffer[bufPos] = '\0';      // Null terminate
       } else {
         #ifdef SERIALCOMMAND_DEBUG
-          target.println("Line buffer is full - increase SERIALCOMMAND_BUFFER");
+          target.println(F("Line buffer is full - increase SERIALCOMMAND_BUFFER"));
         #endif
       }
     }

--- a/SerialCommand.cpp
+++ b/SerialCommand.cpp
@@ -32,7 +32,8 @@ SerialCommand::SerialCommand(int maxCommands)
     defaultHandler(NULL),
     term('\n'),           // default terminator for commands, newline character
     last(NULL),
-    maxCommands(maxCommands)
+    maxCommands(maxCommands),
+	target(Serial)
 {
   strcpy(delim, " "); // strtok_r needs a null-terminated string
   clearBuffer();
@@ -46,15 +47,15 @@ SerialCommand::SerialCommand(int maxCommands)
  */
 void SerialCommand::addCommand(const char *command, void (*function)()) {
   #ifdef SERIALCOMMAND_DEBUG
-    Serial.print("Adding command (");
-    Serial.print(commandCount);
-    Serial.print("): ");
-    Serial.println(command);
+    target.print("Adding command (");
+    target.print(commandCount);
+    target.print("): ");
+    target.println(command);
   #endif
 
   if (commandCount >= maxCommands){
     #ifdef SERIALCOMMAND_DEBUG
-    Serial.print("Error: maxCommands was exceeded");
+    target.print("Error: maxCommands was exceeded");
     #endif
     return;
   }
@@ -78,16 +79,16 @@ void SerialCommand::setDefaultHandler(void (*function)(const char *)) {
  * buffer for a prefix command, and calls handlers setup by addCommand() member
  */
 void SerialCommand::readSerial() {
-  while (Serial.available() > 0) {
-    char inChar = Serial.read();   // Read single available character, there may be more waiting
+  while (target.available() > 0) {
+    char inChar = target.read();   // Read single available character, there may be more waiting
     #ifdef SERIALCOMMAND_DEBUG
-      Serial.print(inChar);   // Echo back to serial stream
+      target.print(inChar);   // Echo back to serial stream
     #endif
 
     if (inChar == term) {     // Check for the terminator (default '\r') meaning end of command
       #ifdef SERIALCOMMAND_DEBUG
-        Serial.print("Received: ");
-        Serial.println(buffer);
+        target.print("Received: ");
+        target.println(buffer);
       #endif
 
       char *command = strtok_r(buffer, delim, &last);   // Search for command at start of buffer
@@ -95,18 +96,18 @@ void SerialCommand::readSerial() {
         boolean matched = false;
         for (int i = 0; i < commandCount; i++) {
           #ifdef SERIALCOMMAND_DEBUG
-            Serial.print("Comparing [");
-            Serial.print(command);
-            Serial.print("] to [");
-            Serial.print(commandList[i].command);
-            Serial.println("]");
+            target.print("Comparing [");
+            target.print(command);
+            target.print("] to [");
+            target.print(commandList[i].command);
+            target.println("]");
           #endif
 
           // Compare the found command against the list of known commands for a match
           if (strncmp(command, commandList[i].command, SERIALCOMMAND_MAXCOMMANDLENGTH) == 0) {
             #ifdef SERIALCOMMAND_DEBUG
-              Serial.print("Matched Command: ");
-              Serial.println(command);
+              target.print("Matched Command: ");
+              target.println(command);
             #endif
 
             // Execute the stored handler function for the command
@@ -127,7 +128,7 @@ void SerialCommand::readSerial() {
         buffer[bufPos] = '\0';      // Null terminate
       } else {
         #ifdef SERIALCOMMAND_DEBUG
-          Serial.println("Line buffer is full - increase SERIALCOMMAND_BUFFER");
+          target.println("Line buffer is full - increase SERIALCOMMAND_BUFFER");
         #endif
       }
     }
@@ -148,4 +149,15 @@ void SerialCommand::clearBuffer() {
  */
 char *SerialCommand::next() {
   return strtok_r(NULL, delim, &last);
+}
+
+/**
+ * Sets the target to send output to and read input from
+ */
+void SerialCommand::setTarget(Stream& target) {
+	this->target = target;
+}
+
+Stream& SerialCommand::getTarget() {
+	return this->target;
 }

--- a/SerialCommand.h
+++ b/SerialCommand.h
@@ -54,8 +54,8 @@ class SerialCommand {
     void clearBuffer();   // Clears the input buffer.
     char *next();         // Returns pointer to next token found in command buffer (for getting arguments to commands).
 
-	void setTarget(Stream& target);
-	Stream& getTarget();
+    void setTarget(Stream* target);
+    Stream* getTarget();
 
   private:
     // Command/handler dictionary
@@ -66,7 +66,7 @@ class SerialCommand {
     SerialCommandCallback *commandList;   // Actual definition for command/handler array
     byte commandCount;
 
-	Stream& target;
+    Stream* target;
 
     // Pointer to the default handler function
     void (*defaultHandler)(const char *);

--- a/SerialCommand.h
+++ b/SerialCommand.h
@@ -54,6 +54,9 @@ class SerialCommand {
     void clearBuffer();   // Clears the input buffer.
     char *next();         // Returns pointer to next token found in command buffer (for getting arguments to commands).
 
+	void setTarget(Stream& target);
+	Stream& getTarget();
+
   private:
     // Command/handler dictionary
     struct SerialCommandCallback {
@@ -62,6 +65,8 @@ class SerialCommand {
     };                                    // Data structure to hold Command/Handler function key-value pairs
     SerialCommandCallback *commandList;   // Actual definition for command/handler array
     byte commandCount;
+
+	Stream& target;
 
     // Pointer to the default handler function
     void (*defaultHandler)(const char *);


### PR DESCRIPTION
This PR updates SerialCommand to allow external code to call setTarget to set any Stream as target. I have added this in order to support a TCP client and not just a Serial connection

The PR shouldn't break the default behavior using Serial connection.

Once this PR is merged I will update my homeduino branch and do a PR there to add TCP client support there.
